### PR TITLE
Fix stress tensor

### DIFF
--- a/src/Functions/stress_tensor.jl
+++ b/src/Functions/stress_tensor.jl
@@ -62,12 +62,13 @@ function (f::ElementStressTensor)(u::DisplacementResult; element_dofs=false)
     n_basefuncs = getnbasefunctions(st.cellvalues)
     n_quad = getnquadpoints(st.cellvalues)
     dim = TopOptProblems.getdim(st.problem)
-    return sum(
-        map(1:n_basefuncs, 1:n_quad) do a, q_point
+    return sum(map(1:n_quad) do  q_point
+        dΩ = getdetJdV(st.cellvalues, q_point) 
+        sum(map(1:n_basefuncs) do a   
             _u = cellu[dim * (a - 1) .+ (1:dim)]
             return tensor_kernel(f, q_point, a)(DisplacementResult(_u))
-        end,
-    )
+        end) * dΩ
+    end)
 end
 
 @params struct ElementStressTensorKernel{T} <: AbstractFunction{T}

--- a/src/Functions/stress_tensor.jl
+++ b/src/Functions/stress_tensor.jl
@@ -83,8 +83,8 @@ function (f::ElementStressTensorKernel)(u::DisplacementResult)
     @unpack E, ν, q_point, a, cellvalues = f
     ∇ϕ = Vector(shape_gradient(cellvalues, q_point, a))
     ϵ = (u.u .* ∇ϕ' .+ ∇ϕ .* u.u') ./ 2
-    c1 = E * ν / (1 - ν^2) * sum(diag(ϵ))
-    c2 = E * ν * (1 + ν)
+    c1 = E * ν / ((1 + ν)*(1 - 2*ν)) * sum(diag(ϵ))
+    c2 = E / (1 + ν)
     return c1 * I + c2 * ϵ
 end
 function ChainRulesCore.rrule(f::ElementStressTensorKernel, u::DisplacementResult)

--- a/src/Functions/stress_tensor.jl
+++ b/src/Functions/stress_tensor.jl
@@ -62,13 +62,14 @@ function (f::ElementStressTensor)(u::DisplacementResult; element_dofs=false)
     n_basefuncs = getnbasefunctions(st.cellvalues)
     n_quad = getnquadpoints(st.cellvalues)
     dim = TopOptProblems.getdim(st.problem)
+    V = sum(st.cellvalues.detJdV)
     return sum(map(1:n_quad) do  q_point
         dΩ = getdetJdV(st.cellvalues, q_point) 
         sum(map(1:n_basefuncs) do a   
             _u = cellu[dim * (a - 1) .+ (1:dim)]
             return tensor_kernel(f, q_point, a)(DisplacementResult(_u))
         end) * dΩ
-    end)
+    end) ./ V
 end
 
 @params struct ElementStressTensorKernel{T} <: AbstractFunction{T}


### PR DESCRIPTION
Fixes the stress tensor formulation by:
 1. modifying the quadrature to iterate over all basis functions and all quadrature points
 2.  Dividing the stress term integrated over the entire element by the volume of the element
 3. Modifying the stress kernel equations to align with with Hooke's law for homogenous isotropic materials

The results appear to closely mimic the Abaqus solution now for several test cases which suggests the issue is fixed. 
